### PR TITLE
Switch Windows WebView installer to bootstrapper

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -17,8 +17,8 @@
     ],
     "windows": {
       "webviewInstallMode": {
-        "type": "offlineInstaller",
-        "silent": true
+        "type": "downloadBootstrapper",
+        "silent": false
       },
       "nsis": {
         "installerIcon": "icons/installer.ico",


### PR DESCRIPTION
## Summary
- configure the Windows webview installation to use the download bootstrapper and disable silent mode so users can see installer prompts

## Testing
- pnpm tauri:build *(fails in container: missing system dependency `javascriptcoregtk-4.1` while attempting to build the Tauri bundle)*

------
https://chatgpt.com/codex/tasks/task_e_68dcff8a0d088331a15f73b874ed02fe