### PR TITLE
Add WebView2 runtime check on Windows startup

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -2,10 +2,33 @@
 
 mod notes;
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use notes::{set_notes_root, NotesWatcherState};
 use tauri::Manager;
+
+#[cfg(target_os = "windows")]
+fn ensure_webview2_installed() -> Result<(), String> {
+    const WEBVIEW_RELATIVE_PATH: &str = "Microsoft\\EdgeWebView\\Application\\msedgewebview2.exe";
+
+    let env_vars = ["ProgramFiles", "ProgramFiles(x86)"];
+
+    for var in env_vars.iter().copied() {
+        if let Ok(dir) = std::env::var(var) {
+            let candidate = Path::new(&dir).join(WEBVIEW_RELATIVE_PATH);
+            if candidate.exists() {
+                return Ok(());
+            }
+        }
+    }
+
+    Err("Microsoft Edge WebView2 Runtime is not installed on this system.".to_string())
+}
+
+#[cfg(not(target_os = "windows"))]
+fn ensure_webview2_installed() -> Result<(), String> {
+    Ok(())
+}
 
 fn main() {
     let builder = tauri::Builder::default()
@@ -24,6 +47,17 @@ fn main() {
         .manage(NotesWatcherState::default())
         .invoke_handler(tauri::generate_handler![set_notes_root])
         .setup(|app| {
+            if let Err(err) = ensure_webview2_installed() {
+                tauri::api::dialog::blocking::message::<tauri::Wry, _>(
+                    None,
+                    "WebView2 Runtime Required",
+                    format!(
+                        "{}\n\nPlease install the WebView2 runtime from https://go.microsoft.com/fwlink/p/?LinkId=2124703 and restart the application.",
+                        err
+                    ),
+                );
+                return Err(Box::new(std::io::Error::new(std::io::ErrorKind::Other, err)));
+            }
             if let Ok(root) = std::env::var("NOTES_ROOT") {
                 if !root.trim().is_empty() {
                     let handle = app.handle();


### PR DESCRIPTION
## Summary
- add a Windows-only helper that ensures the Microsoft Edge WebView2 runtime exists in Program Files directories
- trigger a blocking dialog during setup if the runtime is missing so Windows users receive installation guidance

## Testing
- cargo fmt --manifest-path src-tauri/Cargo.toml

------
https://chatgpt.com/codex/tasks/task_e_68dcff8b09b88331980809b4ae656bbd