### PR TITLE
Use dialog plugin for WebView2 warning

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -6,6 +6,7 @@ use std::path::{Path, PathBuf};
 
 use notes::{set_notes_root, NotesWatcherState};
 use tauri::Manager;
+use tauri_plugin_dialog::DialogExt;
 
 #[cfg(target_os = "windows")]
 fn ensure_webview2_installed() -> Result<(), String> {
@@ -48,14 +49,14 @@ fn main() {
         .invoke_handler(tauri::generate_handler![set_notes_root])
         .setup(|app| {
             if let Err(err) = ensure_webview2_installed() {
-                tauri::api::dialog::blocking::message::<tauri::Wry, _>(
-                    None,
-                    "WebView2 Runtime Required",
-                    format!(
-                        "{}\n\nPlease install the WebView2 runtime from https://go.microsoft.com/fwlink/p/?LinkId=2124703 and restart the application.",
-                        err
-                    ),
+                let message = format!(
+                    "{}\n\nPlease install the WebView2 runtime from https://go.microsoft.com/fwlink/p/?LinkId=2124703 and restart the application.",
+                    err
                 );
+                app.dialog()
+                    .message(message)
+                    .title("WebView2 Runtime Required")
+                    .blocking_show();
                 return Err(Box::new(std::io::Error::new(std::io::ErrorKind::Other, err)));
             }
             if let Ok(root) = std::env::var("NOTES_ROOT") {


### PR DESCRIPTION
## Summary
- import the dialog plugin extension trait for access to the dialog API
- replace the direct tauri dialog invocation with the plugin-based dialog helper while preserving error handling

## Testing
- pnpm tauri build *(fails: Command "tauri" not found)*

------
https://chatgpt.com/codex/tasks/task_e_68dd0651047c8331a4d4c8949acaacc5