### PR TITLE
Improve dashboard nav responsiveness on small screens

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -104,7 +104,7 @@ function AuthenticatedLayout() {
           </div>
         </div>
         <nav className="border-t border-border/60">
-          <div className="mx-auto flex w-full max-w-5xl gap-4 px-6 py-3 text-sm">
+          <div className="mx-auto flex w-full max-w-5xl flex-wrap items-center gap-2 overflow-x-auto px-4 py-3 text-sm sm:flex-nowrap sm:gap-4 sm:px-6">
             <NavLink
               to="/dashboard"
               end


### PR DESCRIPTION
## Summary
- allow the dashboard navigation bar to wrap or scroll horizontally on very small screens
- tweak spacing and padding so buttons retain their styling without doubled gaps when wrapping

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68dd6319f89483318586b7b42478c791