### PR TITLE
Adjust AppLayout search input padding logic

### DIFF
--- a/src/components/AppLayout.tsx
+++ b/src/components/AppLayout.tsx
@@ -65,7 +65,10 @@ export function AppLayout({
               value={searchValue}
               onChange={event => onSearchChange(event.target.value)}
               placeholder={searchPlaceholder ?? '搜索'}
-              className="h-12 w-full rounded-full border border-border bg-surface pl-12 pr-28 text-sm text-text shadow-inner shadow-black/5 outline-none transition focus:border-primary/60 focus:bg-surface-hover"
+              className={clsx(
+                'h-12 w-full rounded-full border border-border bg-surface pl-12 text-sm text-text shadow-inner shadow-black/5 outline-none transition focus:border-primary/60 focus:bg-surface-hover',
+                commandPalette ? 'pr-28' : 'pr-4 sm:pr-6',
+              )}
             />
             {commandPalette && (
               <button

--- a/src/components/__tests__/AppLayout.test.tsx
+++ b/src/components/__tests__/AppLayout.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react'
+import { render, screen, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { useState } from 'react'
 import { describe, expect, it } from 'vitest'
@@ -62,5 +62,42 @@ describe('AppLayout', () => {
     )
 
     expect(screen.getByTestId('filters')).toBeInTheDocument()
+  })
+
+  it('adjusts search input padding based on command palette availability', () => {
+    const baseProps = {
+      title: '搜索布局',
+      searchValue: '',
+      onSearchChange: (_value: string) => {},
+    }
+
+    const { rerender, container } = render(
+      <AppLayout {...baseProps}>
+        <div>内容</div>
+      </AppLayout>,
+    )
+
+    const searchInput = within(container).getByPlaceholderText('搜索')
+    expect(searchInput).toHaveClass('pr-4', 'sm:pr-6')
+    expect(searchInput).not.toHaveClass('pr-28')
+
+    rerender(
+      <AppLayout
+        {...baseProps}
+        commandPalette={{
+          items: [],
+          isOpen: false,
+          onOpen: () => {},
+          onClose: () => {},
+          onSelect: (_item) => {},
+        }}
+      >
+        <div>内容</div>
+      </AppLayout>,
+    )
+
+    const searchInputWithPalette = within(container).getByPlaceholderText('搜索')
+    expect(searchInputWithPalette).toHaveClass('pr-28')
+    expect(searchInputWithPalette).not.toHaveClass('pr-4', 'sm:pr-6')
   })
 })


### PR DESCRIPTION
## Summary
- update the AppLayout search input to build its className with clsx and adjust padding based on command palette availability
- extend the AppLayout test suite to verify the search field padding in both command palette configurations

## Testing
- pnpm vitest run src/components/__tests__/AppLayout.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68dd631b3070833192c831d96c66a19d