### PR TITLE
Add persistent backup history and settings UI

### DIFF
--- a/src/routes/__tests__/BackupHistorySection.test.tsx
+++ b/src/routes/__tests__/BackupHistorySection.test.tsx
@@ -1,0 +1,118 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { ToastProvider } from '../../components/ToastProvider'
+import { DataBackupSection } from '../Settings'
+import { useAuthStore } from '../../stores/auth'
+import { db } from '../../stores/database'
+import { encryptString } from '../../lib/crypto'
+import { runScheduledBackup } from '../../lib/auto-backup'
+import * as backupHistory from '../../stores/backup-history'
+
+const email = 'history-user@example.com'
+const masterPassword = 'HistoryPassw0rd!'
+
+beforeEach(async () => {
+  if (typeof window !== 'undefined') {
+    window.localStorage.clear()
+  }
+  await useAuthStore.getState().logout().catch(() => undefined)
+  backupHistory.persistBackupHistoryRetention({ maxEntries: null, maxAgeMs: null })
+  const existing = await backupHistory.listBackupHistory(email)
+  if (existing.length > 0) {
+    await backupHistory.clearBackupHistory(email)
+  }
+  const passwordRows = await db.passwords.where('ownerEmail').equals(email).toArray()
+  await Promise.all(
+    passwordRows
+      .map(row => row.id)
+      .filter((id): id is number => typeof id === 'number')
+      .map(id => db.passwords.delete(id)),
+  )
+  await db.users.delete(email)
+})
+
+afterEach(async () => {
+  await useAuthStore.getState().logout().catch(() => undefined)
+})
+
+async function createHistoryEntries() {
+  await db.open()
+  const auth = useAuthStore.getState()
+  const register = await auth.register(email, masterPassword)
+  expect(register.success).toBe(true)
+  const encryptionKey = useAuthStore.getState().encryptionKey
+  expect(encryptionKey).toBeInstanceOf(Uint8Array)
+  const keyBytes = encryptionKey as Uint8Array
+
+  const now = Date.now()
+  const firstCipher = await encryptString(keyBytes, 'preview-secret')
+  await db.passwords.add({
+    ownerEmail: email,
+    title: 'Preview Secret',
+    username: 'alice',
+    passwordCipher: firstCipher,
+    createdAt: now,
+    updatedAt: now,
+  })
+
+  await runScheduledBackup({
+    auth: { email, encryptionKey: keyBytes, masterPassword, useSessionKey: false },
+    backupPath: 'C:/mock/backups',
+    isTauri: true,
+    jsonFilters: [],
+    allowDialogFallback: true,
+  })
+
+  const secondCipher = await encryptString(keyBytes, 'diff-secret')
+  await db.passwords.add({
+    ownerEmail: email,
+    title: 'Diff Secret',
+    username: 'bob',
+    passwordCipher: secondCipher,
+    createdAt: now + 500,
+    updatedAt: now + 500,
+  })
+
+  await runScheduledBackup({
+    auth: { email, encryptionKey: keyBytes, masterPassword, useSessionKey: false },
+    backupPath: 'C:/mock/backups',
+    isTauri: true,
+    jsonFilters: [],
+    allowDialogFallback: true,
+  })
+
+  return backupHistory.listBackupHistory(email)
+}
+
+describe('DataBackupSection history panel', () => {
+  it('renders backup history entries with preview and diff controls', async () => {
+    const entries = await createHistoryEntries()
+    expect(entries.length).toBeGreaterThanOrEqual(2)
+
+    render(
+      <ToastProvider>
+        <DataBackupSection />
+      </ToastProvider>,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText(entries[0]!.fileName)).toBeInTheDocument()
+    })
+
+    expect(screen.getByText('历史保留策略')).toBeInTheDocument()
+
+    const previewButtons = screen.getAllByRole('button', { name: '预览' })
+    fireEvent.click(previewButtons[0]!)
+    await waitFor(() => {
+      expect(screen.getByText(/"passwords":/)).toBeInTheDocument()
+    })
+
+    const diffCheckboxes = screen.getAllByLabelText('对比')
+    fireEvent.click(diffCheckboxes[0]!)
+    fireEvent.click(diffCheckboxes[1]!)
+
+    await waitFor(() => {
+      expect(screen.getByText(/JSON 差异/)).toBeInTheDocument()
+    })
+  }, 20000)
+})

--- a/src/stores/backup-history.ts
+++ b/src/stores/backup-history.ts
@@ -1,0 +1,312 @@
+import Dexie, { Table } from 'dexie'
+
+export type BackupHistorySummary = {
+  version: number
+  counts: {
+    passwords: number
+    sites: number
+    docs: number
+    notes: number
+  }
+  profile?: {
+    displayName: string | null
+    hasAvatar: boolean
+  } | null
+}
+
+export type BackupHistoryGithubMeta = {
+  path?: string | null
+  commitSha?: string | null
+  htmlUrl?: string | null
+  uploadedAt?: number | null
+} | null
+
+export type BackupHistoryRetentionPolicy = {
+  maxEntries?: number | null
+  maxAgeMs?: number | null
+}
+
+type BackupHistoryRow = {
+  id?: number
+  ownerEmail: string
+  fileName: string
+  exportedAt: number
+  checksum: string
+  size: number
+  content: string
+  summary: BackupHistorySummary
+  destinationPath?: string | null
+  github?: BackupHistoryGithubMeta
+  createdAt: number
+  updatedAt: number
+}
+
+export type BackupHistoryEntry = BackupHistoryRow & { id: number }
+
+const HISTORY_DB_NAME = 'PersonalBackupHistory'
+const HISTORY_TABLE_NAME = 'entries'
+const HISTORY_RETENTION_STORAGE_KEY = 'pms-backup-history-retention'
+
+export const DEFAULT_BACKUP_HISTORY_RETENTION: Required<BackupHistoryRetentionPolicy> = {
+  maxEntries: 20,
+  maxAgeMs: 90 * 24 * 60 * 60 * 1000,
+}
+
+function hasIndexedDbSupport(): boolean {
+  try {
+    return typeof indexedDB !== 'undefined'
+  } catch (error) {
+    console.warn('IndexedDB unavailable for backup history', error)
+    return false
+  }
+}
+
+class BackupHistoryDatabase extends Dexie {
+  entries!: Table<BackupHistoryRow, number>
+
+  constructor() {
+    super(HISTORY_DB_NAME)
+    this.version(1).stores({
+      [HISTORY_TABLE_NAME]: '++id, ownerEmail, exportedAt, [ownerEmail+exportedAt]',
+    })
+  }
+}
+
+let databaseInstance: BackupHistoryDatabase | null = null
+
+function getDatabase(): BackupHistoryDatabase | null {
+  if (!hasIndexedDbSupport()) {
+    return null
+  }
+  if (!databaseInstance) {
+    databaseInstance = new BackupHistoryDatabase()
+  }
+  return databaseInstance
+}
+
+function getTable(): Table<BackupHistoryRow, number> | null {
+  const db = getDatabase()
+  return db ? db.table<BackupHistoryRow, number>(HISTORY_TABLE_NAME) : null
+}
+
+function normalizeRetention(policy: BackupHistoryRetentionPolicy | null | undefined): BackupHistoryRetentionPolicy {
+  const normalized: BackupHistoryRetentionPolicy = {}
+  if (policy) {
+    const { maxEntries, maxAgeMs } = policy
+    if (maxEntries === null) {
+      normalized.maxEntries = null
+    } else if (typeof maxEntries === 'number' && Number.isFinite(maxEntries) && maxEntries > 0) {
+      normalized.maxEntries = Math.floor(maxEntries)
+    }
+    if (maxAgeMs === null) {
+      normalized.maxAgeMs = null
+    } else if (typeof maxAgeMs === 'number' && Number.isFinite(maxAgeMs) && maxAgeMs > 0) {
+      normalized.maxAgeMs = Math.floor(maxAgeMs)
+    }
+  }
+  if (!('maxEntries' in normalized)) {
+    normalized.maxEntries = DEFAULT_BACKUP_HISTORY_RETENTION.maxEntries
+  }
+  if (!('maxAgeMs' in normalized)) {
+    normalized.maxAgeMs = DEFAULT_BACKUP_HISTORY_RETENTION.maxAgeMs
+  }
+  return normalized
+}
+
+function sanitizeStoredRetention(value: unknown): BackupHistoryRetentionPolicy | null {
+  if (!value || typeof value !== 'object') return null
+  const policy = value as BackupHistoryRetentionPolicy
+  const result: BackupHistoryRetentionPolicy = {}
+  if (policy.maxEntries === null) {
+    result.maxEntries = null
+  } else if (typeof policy.maxEntries === 'number' && Number.isFinite(policy.maxEntries) && policy.maxEntries > 0) {
+    result.maxEntries = Math.floor(policy.maxEntries)
+  }
+  if (policy.maxAgeMs === null) {
+    result.maxAgeMs = null
+  } else if (typeof policy.maxAgeMs === 'number' && Number.isFinite(policy.maxAgeMs) && policy.maxAgeMs > 0) {
+    result.maxAgeMs = Math.floor(policy.maxAgeMs)
+  }
+  return result
+}
+
+export function readStoredBackupHistoryRetention(): BackupHistoryRetentionPolicy {
+  if (typeof window === 'undefined') {
+    return { ...DEFAULT_BACKUP_HISTORY_RETENTION }
+  }
+  try {
+    const raw = window.localStorage.getItem(HISTORY_RETENTION_STORAGE_KEY)
+    if (!raw) {
+      return { ...DEFAULT_BACKUP_HISTORY_RETENTION }
+    }
+    const parsed = JSON.parse(raw)
+    const sanitized = sanitizeStoredRetention(parsed)
+    if (!sanitized) {
+      return { ...DEFAULT_BACKUP_HISTORY_RETENTION }
+    }
+    return normalizeRetention(sanitized)
+  } catch (error) {
+    console.warn('Failed to read backup history retention', error)
+    return { ...DEFAULT_BACKUP_HISTORY_RETENTION }
+  }
+}
+
+export function persistBackupHistoryRetention(policy: BackupHistoryRetentionPolicy): void {
+  if (typeof window === 'undefined') {
+    return
+  }
+  try {
+    const normalized = normalizeRetention(policy)
+    window.localStorage.setItem(HISTORY_RETENTION_STORAGE_KEY, JSON.stringify(normalized))
+  } catch (error) {
+    console.warn('Failed to persist backup history retention', error)
+  }
+}
+
+function resolveRetention(policy?: BackupHistoryRetentionPolicy | null): BackupHistoryRetentionPolicy {
+  if (policy) {
+    return normalizeRetention(policy)
+  }
+  return readStoredBackupHistoryRetention()
+}
+
+async function computeChecksum(content: string): Promise<string> {
+  if (typeof crypto === 'undefined' || !crypto.subtle) {
+    throw new Error('Crypto digest API unavailable')
+  }
+  const encoder = new TextEncoder()
+  const bytes = encoder.encode(content)
+  const digest = await crypto.subtle.digest('SHA-256', bytes)
+  return Array.from(new Uint8Array(digest))
+    .map(value => value.toString(16).padStart(2, '0'))
+    .join('')
+}
+
+export async function recordBackupHistory(
+  input: {
+    ownerEmail: string
+    fileName: string
+    exportedAt: number
+    content: string
+    summary: BackupHistorySummary
+    destinationPath?: string | null
+    github?: BackupHistoryGithubMeta
+  },
+  retention?: BackupHistoryRetentionPolicy | null,
+): Promise<number | null> {
+  const table = getTable()
+  if (!table) {
+    return null
+  }
+  const normalizedRetention = resolveRetention(retention)
+  const createdAt = Date.now()
+  const checksum = await computeChecksum(input.content)
+  const size = new TextEncoder().encode(input.content).length
+  const entry: BackupHistoryRow = {
+    ownerEmail: input.ownerEmail,
+    fileName: input.fileName,
+    exportedAt: input.exportedAt,
+    checksum,
+    size,
+    content: input.content,
+    summary: input.summary,
+    destinationPath: input.destinationPath ?? null,
+    github: input.github ?? null,
+    createdAt,
+    updatedAt: createdAt,
+  }
+  const id = await table.add(entry)
+  await applyBackupHistoryRetention(input.ownerEmail, normalizedRetention)
+  return id
+}
+
+export async function listBackupHistory(
+  ownerEmail: string,
+  options: { limit?: number } = {},
+): Promise<BackupHistoryEntry[]> {
+  const table = getTable()
+  if (!table) {
+    return []
+  }
+  const query = table
+    .where('[ownerEmail+exportedAt]')
+    .between([ownerEmail, Dexie.minKey], [ownerEmail, Dexie.maxKey])
+    .reverse()
+  if (typeof options.limit === 'number' && Number.isFinite(options.limit) && options.limit > 0) {
+    return (await query.limit(Math.floor(options.limit)).toArray()) as BackupHistoryEntry[]
+  }
+  return (await query.toArray()) as BackupHistoryEntry[]
+}
+
+export async function getBackupHistoryEntry(id: number): Promise<BackupHistoryEntry | undefined> {
+  const table = getTable()
+  if (!table) {
+    return undefined
+  }
+  const record = await table.get(id)
+  if (!record || typeof record.id !== 'number') {
+    return undefined
+  }
+  return record as BackupHistoryEntry
+}
+
+export async function clearBackupHistory(ownerEmail: string): Promise<number> {
+  const table = getTable()
+  if (!table) {
+    return 0
+  }
+  const records = await table.where('ownerEmail').equals(ownerEmail).primaryKeys()
+  if (records.length === 0) {
+    return 0
+  }
+  await table.bulkDelete(records as number[])
+  return records.length
+}
+
+export async function applyBackupHistoryRetention(
+  ownerEmail: string,
+  policy?: BackupHistoryRetentionPolicy,
+): Promise<number> {
+  const table = getTable()
+  if (!table) {
+    return 0
+  }
+  const normalized = resolveRetention(policy)
+  const keysToDelete = new Set<number>()
+
+  if (normalized.maxAgeMs && normalized.maxAgeMs > 0) {
+    const threshold = Date.now() - normalized.maxAgeMs
+    const outdated = await table
+      .where('[ownerEmail+exportedAt]')
+      .between([ownerEmail, Dexie.minKey], [ownerEmail, threshold])
+      .toArray()
+    for (const entry of outdated) {
+      if (typeof entry.id === 'number') {
+        keysToDelete.add(entry.id)
+      }
+    }
+  }
+
+  if (normalized.maxEntries && normalized.maxEntries > 0) {
+    const rows = await table
+      .where('[ownerEmail+exportedAt]')
+      .between([ownerEmail, Dexie.minKey], [ownerEmail, Dexie.maxKey])
+      .reverse()
+      .toArray()
+    if (rows.length > normalized.maxEntries) {
+      const overflow = rows.slice(normalized.maxEntries)
+      for (const entry of overflow) {
+        if (typeof entry.id === 'number') {
+          keysToDelete.add(entry.id)
+        }
+      }
+    }
+  }
+
+  const ids = Array.from(keysToDelete)
+  if (ids.length === 0) {
+    return 0
+  }
+  await table.bulkDelete(ids)
+  return ids.length
+}

--- a/tests/backup.test.ts
+++ b/tests/backup.test.ts
@@ -1,11 +1,13 @@
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 import { decryptString, encryptString } from '../src/lib/crypto'
+import { runScheduledBackup } from '../src/lib/auto-backup'
 import type { DatabaseClient } from '../src/stores/database'
 
 let exportUserData: typeof import('../src/lib/backup').exportUserData
 let importUserData: typeof import('../src/lib/backup').importUserData
 let useAuthStore: typeof import('../src/stores/auth').useAuthStore
 let databaseClient: DatabaseClient
+let backupHistoryStore: typeof import('../src/stores/backup-history')
 
 const email = 'backup-user@example.com'
 const masterPassword = 'StrongPassw0rd!'
@@ -20,6 +22,7 @@ beforeAll(async () => {
   useAuthStore = authModule.useAuthStore
   const databaseModule = await import('../src/stores/database')
   databaseClient = databaseModule.db
+  backupHistoryStore = await import('../src/stores/backup-history')
 })
 
 function toHex(bytes: Uint8Array) {
@@ -28,7 +31,7 @@ function toHex(bytes: Uint8Array) {
     .join('')
 }
 
-async function clearUserData(targetEmail: string) {
+async function clearUserData(targetEmail: string, options: { keepHistory?: boolean } = {}) {
   const passwordRows = await databaseClient.passwords.where('ownerEmail').equals(targetEmail).toArray()
   await Promise.all(
     passwordRows
@@ -54,6 +57,10 @@ async function clearUserData(targetEmail: string) {
   )
 
   await databaseClient.users.delete(targetEmail)
+
+  if (!options.keepHistory && backupHistoryStore) {
+    await backupHistoryStore.clearBackupHistory(targetEmail)
+  }
 }
 
 beforeEach(async () => {
@@ -62,6 +69,9 @@ beforeEach(async () => {
   }
   await useAuthStore.getState().logout().catch(() => undefined)
   await clearUserData(email)
+  if (backupHistoryStore) {
+    backupHistoryStore.persistBackupHistoryRetention({ maxEntries: null, maxAgeMs: null })
+  }
 })
 
 afterEach(() => {
@@ -108,7 +118,8 @@ describe('user data backup', () => {
       })
 
       const exported = await exportUserData(email, firstKeyBytes, { masterPassword })
-      const backupText = await exported.text()
+      expect(exported.summary.counts.passwords).toBe(1)
+      const backupText = await exported.blob.text()
 
       await auth.logout()
       await clearUserData(email)
@@ -154,9 +165,8 @@ describe('user data backup', () => {
     const sessionKey = useAuthStore.getState().encryptionKey
     expect(sessionKey).toBeInstanceOf(Uint8Array)
 
-    await expect(
-      exportUserData(email, sessionKey as Uint8Array, { allowSessionKey: true }),
-    ).resolves.toBeInstanceOf(Blob)
+    const result = await exportUserData(email, sessionKey as Uint8Array, { allowSessionKey: true })
+    expect(result.blob).toBeInstanceOf(Blob)
   })
 
   it('requires the master password when session-key export is not enabled', async () => {
@@ -173,4 +183,187 @@ describe('user data backup', () => {
       '导出备份前请输入主密码。',
     )
   })
+
+  it(
+    'records backup history metadata and applies retention',
+    async () => {
+    await databaseClient.open()
+
+    const auth = useAuthStore.getState()
+    const register = await auth.register(email, masterPassword)
+    expect(register.success).toBe(true)
+
+    const encryptionKey = useAuthStore.getState().encryptionKey
+    expect(encryptionKey).toBeInstanceOf(Uint8Array)
+    const keyBytes = encryptionKey as Uint8Array
+
+    const now = Date.now()
+    const cipher = await encryptString(keyBytes, 'history-secret-1')
+    await databaseClient.passwords.add({
+      ownerEmail: email,
+      title: 'History One',
+      username: 'alice',
+      passwordCipher: cipher,
+      createdAt: now,
+      updatedAt: now,
+    })
+
+    const firstBackup = await runScheduledBackup({
+      auth: { email, encryptionKey: keyBytes, masterPassword, useSessionKey: false },
+      backupPath: 'C:/mock/backups',
+      isTauri: true,
+      jsonFilters: [],
+      allowDialogFallback: true,
+      historyRetention: { maxEntries: null, maxAgeMs: null },
+    })
+
+    expect(firstBackup).not.toBeNull()
+    const historyAfterFirst = await backupHistoryStore.listBackupHistory(email)
+    expect(historyAfterFirst).toHaveLength(1)
+    const firstEntry = historyAfterFirst[0]!
+    expect(firstEntry.fileName).toContain('pms-backup')
+    expect(firstEntry.summary.counts.passwords).toBe(1)
+    expect(firstEntry.checksum).toHaveLength(64)
+    expect(() => JSON.parse(firstEntry.content)).not.toThrow()
+    expect(firstBackup?.historyEntryId).toBe(firstEntry.id)
+
+    const secondCipher = await encryptString(keyBytes, 'history-secret-2')
+    await databaseClient.passwords.add({
+      ownerEmail: email,
+      title: 'History Two',
+      username: 'bob',
+      passwordCipher: secondCipher,
+      createdAt: now + 1000,
+      updatedAt: now + 1000,
+    })
+
+    const secondBackup = await runScheduledBackup({
+      auth: { email, encryptionKey: keyBytes, masterPassword, useSessionKey: false },
+      backupPath: 'C:/mock/backups',
+      isTauri: true,
+      jsonFilters: [],
+      allowDialogFallback: true,
+      historyRetention: { maxEntries: 1, maxAgeMs: null },
+    })
+
+    expect(secondBackup).not.toBeNull()
+    expect(secondBackup?.historyEntryId).not.toBe(firstBackup?.historyEntryId)
+
+    const historyAfterSecond = await backupHistoryStore.listBackupHistory(email)
+    expect(historyAfterSecond).toHaveLength(1)
+    const latestEntry = historyAfterSecond[0]!
+    expect(latestEntry.summary.counts.passwords).toBe(2)
+    },
+    LONG_RUNNING_TEST_TIMEOUT,
+  )
+
+  it(
+    'restores data from persisted backup history',
+    async () => {
+    await databaseClient.open()
+
+    const auth = useAuthStore.getState()
+    const register = await auth.register(email, masterPassword)
+    expect(register.success).toBe(true)
+
+    const encryptionKey = useAuthStore.getState().encryptionKey
+    expect(encryptionKey).toBeInstanceOf(Uint8Array)
+    const keyBytes = encryptionKey as Uint8Array
+
+    const now = Date.now()
+    const cipher = await encryptString(keyBytes, 'history-restore')
+    await databaseClient.passwords.add({
+      ownerEmail: email,
+      title: 'Restore Entry',
+      username: 'carol',
+      passwordCipher: cipher,
+      createdAt: now,
+      updatedAt: now,
+    })
+
+    const backupResult = await runScheduledBackup({
+      auth: { email, encryptionKey: keyBytes, masterPassword, useSessionKey: false },
+      backupPath: 'C:/mock/backups',
+      isTauri: true,
+      jsonFilters: [],
+      allowDialogFallback: true,
+    })
+
+    expect(backupResult).not.toBeNull()
+
+    const history = await backupHistoryStore.listBackupHistory(email)
+    expect(history).toHaveLength(1)
+    const storedEntry = history[0]!
+
+    await auth.logout()
+    await clearUserData(email, { keepHistory: true })
+
+    const secondRegister = await auth.register(email, masterPassword)
+    expect(secondRegister.success).toBe(true)
+
+    const newKey = useAuthStore.getState().encryptionKey
+    expect(newKey).toBeInstanceOf(Uint8Array)
+    const newKeyBytes = newKey as Uint8Array
+
+    const importResult = await importUserData(storedEntry.content, newKeyBytes, masterPassword)
+    expect(importResult.passwords).toBe(1)
+
+    const restoredPasswords = await databaseClient.passwords.where('ownerEmail').equals(email).toArray()
+    expect(restoredPasswords).toHaveLength(1)
+    const restoredSecret = await decryptString(newKeyBytes, restoredPasswords[0]!.passwordCipher)
+    expect(restoredSecret).toBe('history-restore')
+    },
+    LONG_RUNNING_TEST_TIMEOUT,
+  )
+
+  it(
+    'cleans backup history by age threshold',
+    async () => {
+    await databaseClient.open()
+
+    const auth = useAuthStore.getState()
+    const register = await auth.register(email, masterPassword)
+    expect(register.success).toBe(true)
+
+    const encryptionKey = useAuthStore.getState().encryptionKey
+    const keyBytes = encryptionKey as Uint8Array
+
+    const backup = await runScheduledBackup({
+      auth: { email, encryptionKey: keyBytes, masterPassword, useSessionKey: false },
+      backupPath: 'C:/mock/backups',
+      isTauri: true,
+      jsonFilters: [],
+      allowDialogFallback: true,
+    })
+
+    expect(backup).not.toBeNull()
+    const entries = await backupHistoryStore.listBackupHistory(email)
+    expect(entries).toHaveLength(1)
+    const [latest] = entries
+    const dayMs = 24 * 60 * 60 * 1000
+
+    await backupHistoryStore.recordBackupHistory(
+      {
+        ownerEmail: email,
+        fileName: 'manual-old.json',
+        exportedAt: Date.now() - dayMs * 120,
+        content: latest.content,
+        summary: latest.summary,
+        destinationPath: null,
+        github: null,
+      },
+      null,
+    )
+
+    const combined = await backupHistoryStore.listBackupHistory(email)
+    expect(combined.length).toBeGreaterThanOrEqual(2)
+
+    const removed = await backupHistoryStore.applyBackupHistoryRetention(email, { maxEntries: null, maxAgeMs: dayMs * 30 })
+    expect(removed).toBeGreaterThanOrEqual(1)
+
+    const remaining = await backupHistoryStore.listBackupHistory(email)
+    expect(remaining).toHaveLength(1)
+    },
+    LONG_RUNNING_TEST_TIMEOUT,
+  )
 })


### PR DESCRIPTION
## Summary
- add a Dexie-backed backup history store with retention helpers and metadata utilities
- record history entries after scheduled backups and expose preview/diff/restore controls plus retention settings in the data backup UI
- expand backup flow tests and add a history panel component test covering the new interactions

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68dd6f463c7c8331ad09d6781e56ba31