### PR TITLE
Add global search index and integrate command palette

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,6 +14,7 @@ import Inspiration from './routes/Inspiration'
 import { useLock } from './features/lock/LockProvider'
 import ConfirmDialog from './components/ConfirmDialog'
 import { isTauriRuntime } from './env'
+import { CommandPaletteProvider } from './providers/CommandPaletteProvider'
 
 function GuestLayout({ children }: { children: ReactNode }) {
   return (
@@ -258,7 +259,15 @@ export default function App() {
         />
         <Route
           path="/dashboard/*"
-          element={email ? <AuthenticatedLayout /> : <Navigate to="/login" replace />}
+          element={
+            email ? (
+              <CommandPaletteProvider>
+                <AuthenticatedLayout />
+              </CommandPaletteProvider>
+            ) : (
+              <Navigate to="/login" replace />
+            )
+          }
         >
           <Route index element={<Dashboard />} />
           <Route path="passwords" element={<Passwords />} />

--- a/src/components/AppLayout.tsx
+++ b/src/components/AppLayout.tsx
@@ -1,16 +1,7 @@
 import clsx from 'clsx'
 import type { ReactNode } from 'react'
 import { Search as SearchIcon, Plus as PlusIcon, Command as CommandIcon, LayoutGrid, List as ListIcon } from 'lucide-react'
-import { CommandPalette, type CommandItem } from './CommandPalette'
-
-type CommandPaletteConfig = {
-  items: CommandItem[]
-  isOpen: boolean
-  onOpen: () => void
-  onClose: () => void
-  onSelect: (item: CommandItem) => void
-  placeholder?: string
-}
+import { useCommandPalette } from '../providers/CommandPaletteProvider'
 
 type AppLayoutProps = {
   title: string
@@ -21,7 +12,6 @@ type AppLayoutProps = {
   createLabel?: string
   onCreate?: () => void
   children: ReactNode
-  commandPalette?: CommandPaletteConfig
   actions?: ReactNode
   viewMode?: 'card' | 'list'
   onViewModeChange?: (mode: 'card' | 'list') => void
@@ -37,12 +27,12 @@ export function AppLayout({
   createLabel = '新增',
   onCreate,
   children,
-  commandPalette,
   actions,
   viewMode = 'card',
   onViewModeChange,
   filters,
 }: AppLayoutProps) {
+  const { open: openCommandPalette } = useCommandPalette()
   const viewModes: Array<{ value: 'card' | 'list'; label: string; icon: ReactNode }> = [
     { value: 'card', label: '卡片视图', icon: <LayoutGrid className="h-3.5 w-3.5" aria-hidden /> },
     { value: 'list', label: '列表视图', icon: <ListIcon className="h-3.5 w-3.5" aria-hidden /> },
@@ -67,19 +57,17 @@ export function AppLayout({
               placeholder={searchPlaceholder ?? '搜索'}
               className={clsx(
                 'h-12 w-full rounded-full border border-border bg-surface pl-12 text-sm text-text shadow-inner shadow-black/5 outline-none transition focus:border-primary/60 focus:bg-surface-hover',
-                commandPalette ? 'pr-28' : 'pr-4 sm:pr-6',
+                'pr-28',
               )}
             />
-            {commandPalette && (
-              <button
-                type="button"
-                onClick={commandPalette.onOpen}
-                className="absolute right-2 top-1/2 inline-flex -translate-y-1/2 items-center gap-1 rounded-full border border-border bg-surface px-3 py-1 text-xs font-semibold text-text transition hover:bg-surface-hover"
-              >
-                <CommandIcon className="h-3.5 w-3.5" />
-                <span>Ctrl / Cmd + K</span>
-              </button>
-            )}
+            <button
+              type="button"
+              onClick={openCommandPalette}
+              className="absolute right-2 top-1/2 inline-flex -translate-y-1/2 items-center gap-1 rounded-full border border-border bg-surface px-3 py-1 text-xs font-semibold text-text transition hover:bg-surface-hover"
+            >
+              <CommandIcon className="h-3.5 w-3.5" />
+              <span>Ctrl / Cmd + K</span>
+            </button>
           </div>
           <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-end">
             {onViewModeChange && (
@@ -119,15 +107,6 @@ export function AppLayout({
         {filters && <div className="flex flex-wrap gap-3">{filters}</div>}
       </header>
       <section className="no-drag">{children}</section>
-      {commandPalette && (
-        <CommandPalette
-          open={commandPalette.isOpen}
-          onClose={commandPalette.onClose}
-          items={commandPalette.items}
-          onSelect={commandPalette.onSelect}
-          placeholder={commandPalette.placeholder}
-        />
-      )}
     </div>
   )
 }

--- a/src/lib/global-search.ts
+++ b/src/lib/global-search.ts
@@ -1,0 +1,275 @@
+import Fuse from 'fuse.js'
+import { isTauriRuntime } from '../env'
+import { useAuthStore } from '../stores/auth'
+import { getDatabase, getDexieInstance, rebuildSearchIndex, SearchEntryKind, SearchIndexRecord } from '../stores/database'
+import { listNotes, type NoteSummary } from './inspiration-notes'
+
+export type SearchResult = {
+  id: string
+  kind: SearchEntryKind
+  refId: string
+  title: string
+  subtitle?: string
+  keywords: string[]
+  updatedAt: number
+  route: string
+}
+
+const fuseOptions: Fuse.IFuseOptions<SearchIndexRecord> = {
+  includeScore: true,
+  threshold: 0.32,
+  keys: [
+    { name: 'title', weight: 0.7 },
+    { name: 'subtitle', weight: 0.2 },
+    { name: 'keywords', weight: 0.1 },
+  ],
+  ignoreLocation: true,
+  minMatchCharLength: 1,
+}
+
+let cachedOwner: string | null = null
+let desiredOwner: string | null = null
+let cachedEntries: SearchIndexRecord[] = []
+let fuseInstance: Fuse<SearchIndexRecord> | null = null
+let initializePromise: Promise<void> | null = null
+let rebuildTimer: ReturnType<typeof setTimeout> | null = null
+let dexieSubscriptions: Array<() => void> = []
+
+const ROUTE_MAP: Record<SearchEntryKind, string> = {
+  password: '/dashboard/passwords',
+  site: '/dashboard/sites',
+  doc: '/dashboard/docs',
+  note: '/dashboard/inspiration',
+}
+
+export async function setSearchOwner(email: string | null): Promise<void> {
+  const normalized = email?.trim() || null
+  desiredOwner = normalized
+
+  if (!normalized) {
+    clearDexieSubscriptions()
+    cachedOwner = null
+    cachedEntries = []
+    fuseInstance = null
+    return
+  }
+
+  if (normalized === cachedOwner && !initializePromise) {
+    return
+  }
+
+  if (!initializePromise) {
+    initializePromise = initializeForOwner(normalized).finally(() => {
+      initializePromise = null
+    })
+  }
+
+  await initializePromise
+}
+
+export async function searchAll(query: string, limit = 20): Promise<SearchResult[]> {
+  await ensureInitialized()
+  if (!cachedOwner) return []
+  if (!fuseInstance) {
+    await refreshCache()
+  }
+  const trimmed = query.trim()
+  const entries = trimmed
+    ? fuseInstance
+        ?.search(trimmed)
+        .slice(0, limit)
+        .map(result => result.item) ?? []
+    : cachedEntries.slice().sort((a, b) => b.updatedAt - a.updatedAt).slice(0, limit)
+  return entries.map(toSearchResult)
+}
+
+export function requestSearchIndexRefresh(): void {
+  if (!cachedOwner) return
+  scheduleRebuild()
+}
+
+async function ensureInitialized() {
+  if (desiredOwner === null) {
+    const storeEmail = useAuthStore.getState().email ?? null
+    await setSearchOwner(storeEmail)
+    return
+  }
+  if (initializePromise) {
+    await initializePromise
+  }
+}
+
+async function initializeForOwner(ownerEmail: string): Promise<void> {
+  clearDexieSubscriptions()
+  cachedOwner = ownerEmail
+  await rebuildSearchIndex(ownerEmail)
+  await syncNotes(ownerEmail)
+  await refreshCache()
+  setupDexieSubscriptions()
+}
+
+async function refreshCache() {
+  if (!cachedOwner) {
+    cachedEntries = []
+    fuseInstance = null
+    return
+  }
+  const client = await getDatabase()
+  const rows = await client.searchIndex.where('ownerEmail').equals(cachedOwner).toArray()
+  rows.sort((a, b) => b.updatedAt - a.updatedAt)
+  cachedEntries = rows
+  fuseInstance = new Fuse(rows, fuseOptions)
+}
+
+function toSearchResult(entry: SearchIndexRecord): SearchResult {
+  return {
+    id: `${entry.kind}:${entry.refId}`,
+    kind: entry.kind,
+    refId: entry.refId,
+    title: entry.title,
+    subtitle: entry.subtitle,
+    keywords: entry.keywords,
+    updatedAt: entry.updatedAt,
+    route: ROUTE_MAP[entry.kind],
+  }
+}
+
+function scheduleRebuild() {
+  if (rebuildTimer) {
+    clearTimeout(rebuildTimer)
+  }
+  rebuildTimer = setTimeout(async () => {
+    rebuildTimer = null
+    if (!cachedOwner) return
+    try {
+      await rebuildSearchIndex(cachedOwner)
+      await syncNotes(cachedOwner)
+      await refreshCache()
+    } catch (error) {
+      console.warn('Failed to rebuild search index', error)
+    }
+  }, 200)
+}
+
+async function syncNotes(ownerEmail: string) {
+  if (!isTauriRuntime()) {
+    return
+  }
+  try {
+    const notes = await listNotes()
+    const entries = notes.map(note => buildNoteSearchEntry(note, ownerEmail))
+    const client = await getDatabase()
+    await client.searchIndex.where('[ownerEmail+kind]').equals([ownerEmail, 'note']).delete()
+    if (entries.length > 0) {
+      await client.searchIndex.bulkPut(entries)
+    }
+  } catch (error) {
+    console.warn('Failed to synchronize inspiration notes into search index', error)
+  }
+}
+
+function buildNoteSearchEntry(note: NoteSummary, ownerEmail: string): SearchIndexRecord {
+  const subtitle = note.excerpt?.trim() || undefined
+  const tags = Array.isArray(note.tags) ? note.tags.filter(tag => typeof tag === 'string').map(tag => tag.trim()).filter(Boolean) : []
+  const keywords = buildKeywords([note.title, note.excerpt], tags)
+  const updatedAt = note.updatedAt ?? note.createdAt ?? Date.now()
+  return {
+    ownerEmail,
+    kind: 'note',
+    refId: note.id,
+    title: note.title,
+    subtitle,
+    keywords,
+    updatedAt,
+  }
+}
+
+function buildKeywords(values: Array<string | undefined | null>, tags: string[]): string[] {
+  const keywords = new Set<string>()
+  for (const value of values) {
+    if (typeof value !== 'string') continue
+    const trimmed = value.trim()
+    if (!trimmed) continue
+    keywords.add(trimmed)
+  }
+  for (const tag of tags) {
+    if (!tag) continue
+    keywords.add(tag)
+    keywords.add(`#${tag}`)
+  }
+  return Array.from(keywords)
+}
+
+function setupDexieSubscriptions() {
+  const dexie = getDexieInstance()
+  if (!dexie || !cachedOwner) {
+    return
+  }
+
+  const passwordCreating = (_primKey: number | undefined, obj: any) => {
+    if (obj?.ownerEmail === cachedOwner) scheduleRebuild()
+  }
+  const passwordUpdating = (_mod: any, _primKey: any, obj: any) => {
+    if (obj?.ownerEmail === cachedOwner) scheduleRebuild()
+  }
+  const passwordDeleting = (_primKey: any, obj: any) => {
+    if (obj?.ownerEmail === cachedOwner) scheduleRebuild()
+  }
+
+  const siteCreating = (_primKey: number | undefined, obj: any) => {
+    if (obj?.ownerEmail === cachedOwner) scheduleRebuild()
+  }
+  const siteUpdating = (_mod: any, _primKey: any, obj: any) => {
+    if (obj?.ownerEmail === cachedOwner) scheduleRebuild()
+  }
+  const siteDeleting = (_primKey: any, obj: any) => {
+    if (obj?.ownerEmail === cachedOwner) scheduleRebuild()
+  }
+
+  const docCreating = (_primKey: number | undefined, obj: any) => {
+    if (obj?.ownerEmail === cachedOwner) scheduleRebuild()
+  }
+  const docUpdating = (_mod: any, _primKey: any, obj: any) => {
+    if (obj?.ownerEmail === cachedOwner) scheduleRebuild()
+  }
+  const docDeleting = (_primKey: any, obj: any) => {
+    if (obj?.ownerEmail === cachedOwner) scheduleRebuild()
+  }
+
+  dexie.passwords.hook('creating', passwordCreating)
+  dexie.passwords.hook('updating', passwordUpdating)
+  dexie.passwords.hook('deleting', passwordDeleting)
+  dexie.sites.hook('creating', siteCreating)
+  dexie.sites.hook('updating', siteUpdating)
+  dexie.sites.hook('deleting', siteDeleting)
+  dexie.docs.hook('creating', docCreating)
+  dexie.docs.hook('updating', docUpdating)
+  dexie.docs.hook('deleting', docDeleting)
+
+  dexieSubscriptions = [
+    () => dexie.passwords.hook('creating').unsubscribe(passwordCreating),
+    () => dexie.passwords.hook('updating').unsubscribe(passwordUpdating),
+    () => dexie.passwords.hook('deleting').unsubscribe(passwordDeleting),
+    () => dexie.sites.hook('creating').unsubscribe(siteCreating),
+    () => dexie.sites.hook('updating').unsubscribe(siteUpdating),
+    () => dexie.sites.hook('deleting').unsubscribe(siteDeleting),
+    () => dexie.docs.hook('creating').unsubscribe(docCreating),
+    () => dexie.docs.hook('updating').unsubscribe(docUpdating),
+    () => dexie.docs.hook('deleting').unsubscribe(docDeleting),
+  ]
+}
+
+function clearDexieSubscriptions() {
+  if (rebuildTimer) {
+    clearTimeout(rebuildTimer)
+    rebuildTimer = null
+  }
+  if (dexieSubscriptions.length > 0) {
+    try {
+      dexieSubscriptions.forEach(unsubscribe => unsubscribe())
+    } catch (error) {
+      console.warn('Failed to clear Dexie search subscriptions', error)
+    }
+    dexieSubscriptions = []
+  }
+}

--- a/tests/app-navigation.test.tsx
+++ b/tests/app-navigation.test.tsx
@@ -1,10 +1,45 @@
 import { cleanup, render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { ToastProvider } from '../src/components/ToastProvider'
 
 const { mockInit, mockLogout } = vi.hoisted(() => ({
   mockInit: vi.fn(async () => {}),
   mockLogout: vi.fn(async () => {}),
+}))
+
+const { mockSearchAll } = vi.hoisted(() => ({
+  mockSearchAll: vi.fn(async (query: string) => {
+    if (query.includes('文档')) {
+      return [
+        {
+          id: 'doc:1',
+          kind: 'doc',
+          refId: '1',
+          title: '示例文档',
+          subtitle: '文档 · 摘要',
+          keywords: ['文档'],
+          updatedAt: Date.now(),
+          route: '/dashboard/docs',
+        },
+      ]
+    }
+    if (query.includes('网站')) {
+      return [
+        {
+          id: 'site:2',
+          kind: 'site',
+          refId: '2',
+          title: '示例站点',
+          subtitle: '网站 · https://example.com',
+          keywords: ['网站'],
+          updatedAt: Date.now(),
+          route: '/dashboard/sites',
+        },
+      ]
+    }
+    return []
+  }),
 }))
 
 vi.mock('../src/env', () => ({
@@ -53,12 +88,19 @@ vi.mock('../src/routes/Inspiration', () => ({
   default: () => <div>Inspiration Content</div>,
 }))
 
+vi.mock('../src/lib/global-search', () => ({
+  searchAll: mockSearchAll,
+  setSearchOwner: vi.fn(async () => {}),
+  requestSearchIndexRefresh: vi.fn(),
+}))
+
 import App from '../src/App'
 
 describe('App navigation', () => {
   beforeEach(() => {
     mockInit.mockClear()
     mockLogout.mockClear()
+    mockSearchAll.mockClear()
   })
 
   afterEach(() => {
@@ -68,7 +110,11 @@ describe('App navigation', () => {
   it('renders desktop-only inspiration link and navigates to the route', async () => {
     const user = userEvent.setup()
 
-    render(<App />)
+    render(
+      <ToastProvider>
+        <App />
+      </ToastProvider>,
+    )
 
     const inspirationLink = await screen.findByRole('link', { name: '灵感妙记' })
     expect(inspirationLink).toBeInTheDocument()
@@ -76,5 +122,32 @@ describe('App navigation', () => {
     await user.click(inspirationLink)
 
     expect(await screen.findByText('Inspiration Content')).toBeInTheDocument()
+  })
+
+  it('navigates to modules via global search results', async () => {
+    const user = userEvent.setup()
+
+    render(
+      <ToastProvider>
+        <App />
+      </ToastProvider>,
+    )
+
+    const passwordsLink = await screen.findByRole('link', { name: '密码管理' })
+    await user.click(passwordsLink)
+
+    await screen.findByRole('heading', { name: '密码库' })
+
+    const paletteButton = await screen.findByRole('button', { name: 'Ctrl / Cmd + K' })
+    await user.click(paletteButton)
+
+    const searchInput = await screen.findByPlaceholderText('搜索密码、网站、文档或灵感')
+    await user.type(searchInput, '文档')
+
+    const docResult = await screen.findByRole('button', { name: /示例文档/ })
+    await user.click(docResult)
+
+    expect(await screen.findByRole('heading', { name: '文档管理' })).toBeInTheDocument()
+    expect(mockSearchAll).toHaveBeenCalledWith('文档')
   })
 })


### PR DESCRIPTION
## Summary
- add search index schema to Dexie/SQLite and expose rebuild/upsert helpers
- create a global search orchestrator that rebuilds indexes and hydrates notes
- connect the command palette to global search results, refactor module pages to register commands, and cover navigation in tests

## Testing
- pnpm vitest run tests/database.test.ts tests/app-navigation.test.tsx src/components/__tests__/AppLayout.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68dd6f466a6483319d300fb0ce6840e3