### PR TITLE
Fix inspiration panel note summary mocks

### DIFF
--- a/tests/inspiration-panel.test.tsx
+++ b/tests/inspiration-panel.test.tsx
@@ -498,6 +498,7 @@ describe('InspirationPanel handleCreateFile', () => {
           updatedAt: 1,
           excerpt: '',
           searchText: '',
+          attachments: [],
         },
       ] as unknown[])
     createNoteFileMock.mockResolvedValue('Projects/Foo.md')
@@ -555,6 +556,7 @@ describe('InspirationPanel handleCreateFile', () => {
           excerpt: '',
           searchText: '',
           tags: [],
+          attachments: [],
         },
       ] as unknown[])
     listNoteFoldersMock.mockResolvedValue(['Ideas'])


### PR DESCRIPTION
## Summary
- add the `attachments` field to inspiration panel note summary mocks to match the latest `NoteSummary` shape

## Testing
- pnpm test inspiration-panel

------
https://chatgpt.com/codex/tasks/task_e_68dd827c38f48331bfd0441c61a5f536