### PR TITLE
Improve Tauri runtime detection and bootstrap flag

### DIFF
--- a/src/env.ts
+++ b/src/env.ts
@@ -8,45 +8,61 @@ export const isTauriRuntime = (): boolean => {
     isTauri?: TauriFlag
   }
 
+  const markAsTauri = () => {
+    globalWithFlag.isTauri = true
+    return true
+  }
+
   const globalFlag = globalWithFlag.isTauri
 
   if (typeof globalFlag === 'boolean') {
-    if (globalFlag) {
-      return true
-    }
-  } else if (typeof globalFlag === 'function') {
+    return globalFlag
+  }
+
+  if (typeof globalFlag === 'function') {
     try {
       if (globalFlag()) {
-        return true
+        return markAsTauri()
       }
     } catch {
       // ignore errors from custom flag functions
     }
   }
 
+  if (typeof window !== 'undefined') {
+    const tauriWindow = window as unknown as {
+      navigator?: Navigator & { userAgent?: string }
+      __TAURI__?: unknown
+      __TAURI_METADATA__?: unknown
+      __TAURI_IPC__?: unknown
+      __TAURI_INTERNALS__?: unknown
+    }
+
+    if ('__TAURI_INTERNALS__' in tauriWindow && tauriWindow.__TAURI_INTERNALS__) {
+      return markAsTauri()
+    }
+
+    const ua = tauriWindow.navigator?.userAgent
+    if (typeof ua === 'string' && ua.includes('Tauri')) {
+      return markAsTauri()
+    }
+
+    if (
+      typeof tauriWindow.__TAURI__ !== 'undefined' ||
+      typeof tauriWindow.__TAURI_METADATA__ !== 'undefined' ||
+      typeof tauriWindow.__TAURI_IPC__ !== 'undefined'
+    ) {
+      return markAsTauri()
+    }
+  }
+
   try {
     if (coreIsTauri()) {
-      return true
+      return markAsTauri()
     }
   } catch {
     // ignore errors from the core detection helper
   }
 
-  if (typeof window === 'undefined') {
-    return false
-  }
-
-  const tauriWindow = window as unknown as {
-    __TAURI__?: unknown
-    __TAURI_METADATA__?: unknown
-    __TAURI_IPC__?: unknown
-    __TAURI_INTERNALS__?: unknown
-  }
-
-  return (
-    typeof tauriWindow.__TAURI__ !== 'undefined' ||
-    typeof tauriWindow.__TAURI_METADATA__ !== 'undefined' ||
-    typeof tauriWindow.__TAURI_IPC__ !== 'undefined' ||
-    typeof tauriWindow.__TAURI_INTERNALS__ !== 'undefined'
-  )
+  return false
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -12,6 +12,17 @@ import { LockProvider } from './features/lock/LockProvider'
 import { LockScreen } from './features/lock/LockScreen'
 import { initializeTheme, useTheme } from './stores/theme'
 
+const globalWithFlag = globalThis as typeof globalThis & { isTauri?: unknown }
+
+if (typeof window !== 'undefined') {
+  const possibleTauriWindow = window as unknown as { __TAURI_INTERNALS__?: unknown }
+  if ('__TAURI_INTERNALS__' in possibleTauriWindow && possibleTauriWindow.__TAURI_INTERNALS__) {
+    if (typeof globalWithFlag.isTauri === 'undefined') {
+      globalWithFlag.isTauri = true
+    }
+  }
+}
+
 installPanicOverlay()
 
 if (isTauriRuntime()) {


### PR DESCRIPTION
## Summary
- strengthen Tauri runtime detection to rely on window internals and user agent before caching the result globally
- initialize the global Tauri flag in the renderer entry when internals are present to keep downstream checks in sync

## Testing
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68de6792b21c8331a7bfd6fb04566edb