### PR TITLE
Improve Tauri runtime detection

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,5 +1,5 @@
 import { installPanicOverlay } from './lib/error-overlay'
-import { isTauriRuntime } from './env'
+import { ensureTauriRuntimeDetection, isTauriRuntime } from './env'
 import { swCleanup } from './lib/sw-clean'
 import React from 'react'
 import ReactDOM from 'react-dom/client'
@@ -22,6 +22,8 @@ if (typeof window !== 'undefined') {
     }
   }
 }
+
+ensureTauriRuntimeDetection()
 
 installPanicOverlay()
 


### PR DESCRIPTION
## Summary
- add an async Tauri ready listener that marks the runtime when the synchronous checks fail
- ensure the detection bootstrap runs before the React app is rendered
- extend the inspiration panel tests to cover the new detection path

## Testing
- pnpm vitest tests/inspiration-panel.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68de6b09054483319c6e883b097ad4a3