### PR TITLE
Improve Tauri runtime detection robustness

### DIFF
--- a/tests/env-detection.test.ts
+++ b/tests/env-detection.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it, vi } from 'vitest'
+
+describe('Tauri runtime async detection', () => {
+  it('detects when tauri internals appear before ready listener is registered', async () => {
+    vi.resetModules()
+
+    const listenMock = vi.fn(
+      async (_event: string, _handler: () => void): Promise<() => void> => () => {
+        // noop
+      },
+    )
+    const coreIsTauriMock = vi.fn(() => false)
+
+    vi.doMock('@tauri-apps/api/event', () => ({
+      listen: listenMock,
+    }))
+    vi.doMock('@tauri-apps/api/core', () => ({
+      isTauri: coreIsTauriMock,
+    }))
+
+    const tauriWindow = window as typeof window & { __TAURI_INTERNALS__?: unknown }
+    delete tauriWindow.__TAURI_INTERNALS__
+    const globalWithFlag = globalThis as typeof globalThis & { isTauri?: unknown }
+    delete globalWithFlag.isTauri
+
+    const { ensureTauriRuntimeDetection, isTauriRuntime } = await import('../src/env')
+
+    expect(isTauriRuntime()).toBe(false)
+
+    ensureTauriRuntimeDetection()
+
+    tauriWindow.__TAURI_INTERNALS__ = {}
+
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(isTauriRuntime()).toBe(true)
+    expect(listenMock).not.toHaveBeenCalled()
+  })
+})

--- a/tests/inspiration-panel.test.tsx
+++ b/tests/inspiration-panel.test.tsx
@@ -193,6 +193,7 @@ afterEach(() => {
   } else {
     globalForTauri.isTauri = originalGlobalIsTauri
   }
+  delete (window as typeof window & { __TAURI_INTERNALS__?: unknown }).__TAURI_INTERNALS__
 })
 
 afterAll(() => {


### PR DESCRIPTION
## Summary
- ensure the async Tauri detector re-checks synchronously after loading the event API and schedules a microtask fallback
- stop listening once detection succeeds to avoid leaking ready listeners
- add targeted regression coverage for detecting Tauri when internals appear before the ready event

## Testing
- pnpm exec vitest run tests/env-detection.test.ts
- pnpm exec vitest run tests/inspiration-panel.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68de74ebf12083319fe37a7b8e3e1ab9