### PR TITLE
feat: add markdown preview modes

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "react-dom": "^18.2.0",
     "react-markdown": "^10.1.0",
     "react-router-dom": "^6.26.2",
+    "remark-gfm": "^4.0.1",
     "sql.js": "^1.10.2",
     "zustand": "^4.5.2"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -89,6 +89,9 @@ importers:
       react-router-dom:
         specifier: ^6.26.2
         version: 6.30.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      remark-gfm:
+        specifier: ^4.0.1
+        version: 4.0.1
       sql.js:
         specifier: ^1.10.2
         version: 1.13.0


### PR DESCRIPTION
## Summary
- add edit/preview/split display modes to the inspiration markdown editor with responsive layout controls
- render a styled markdown preview using ReactMarkdown with remark-gfm for GFM syntax support
- include remark-gfm as a project dependency to align preview formatting with editor capabilities

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68de8b04083883319e185e2f81bda707