### PR TITLE
fix: add remark-gfm type declaration

### DIFF
--- a/src/types/remark-gfm.d.ts
+++ b/src/types/remark-gfm.d.ts
@@ -1,4 +1,6 @@
 declare module 'remark-gfm' {
-  const remarkGfm: import('unified').Plugin<[]>;
+  const remarkGfm: import('unified').Plugin<[
+    import('remark-gfm').Options?
+  ]>;
   export default remarkGfm;
 }


### PR DESCRIPTION
## Summary
- update the local remark-gfm module declaration to include the plugin options type so TypeScript can resolve the plugin

## Testing
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68de9bbe0fd88331abf4318dc81e0db0