### PR TITLE
fix: expand inspiration note folders on initial load

### DIFF
--- a/src/routes/Docs/InspirationPanel.tsx
+++ b/src/routes/Docs/InspirationPanel.tsx
@@ -1218,6 +1218,7 @@ export function InspirationPanel({ className }: InspirationPanelProps) {
       knownFoldersRef.current = new Set(allPaths)
       foldersInitializedRef.current = true
       if (!hasExpandedFolders) {
+        setExpandedFolders(Array.from(allPaths))
         return
       }
     } else if (!hasExpandedFolders) {


### PR DESCRIPTION
## Summary
- ensure the inspiration note folder tree expands automatically once folders are detected so it is not collapsed by default

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68dea40c1ff08331a0f8d107531cf8fc