### PR TITLE
Avoid auto-expanding inspiration folders on initial load

### DIFF
--- a/src/routes/Docs/InspirationPanel.tsx
+++ b/src/routes/Docs/InspirationPanel.tsx
@@ -1191,7 +1191,6 @@ export function InspirationPanel({ className }: InspirationPanelProps) {
     if (allPaths.size === 0) return
     knownFoldersRef.current = new Set(allPaths)
     foldersInitializedRef.current = true
-    setExpandedFolders(Array.from(allPaths))
   }, [collectAllFolderPaths, hasExpandedFolders])
 
   useEffect(() => {
@@ -1217,11 +1216,9 @@ export function InspirationPanel({ className }: InspirationPanelProps) {
     if (!foldersInitializedRef.current) {
       knownFoldersRef.current = new Set(allPaths)
       foldersInitializedRef.current = true
-      if (!hasExpandedFolders) {
-        setExpandedFolders(Array.from(allPaths))
-        return
-      }
-    } else if (!hasExpandedFolders) {
+    }
+
+    if (!hasExpandedFolders) {
       knownFoldersRef.current = new Set(allPaths)
       return
     }
@@ -1235,7 +1232,7 @@ export function InspirationPanel({ className }: InspirationPanelProps) {
       }
     }
 
-    if (newlyDiscovered.length > 0) {
+    if (newlyDiscovered.length > 0 && hasExpandedFolders) {
       setExpandedFolders(prev => {
         const set = new Set(prev)
         for (const path of newlyDiscovered) {


### PR DESCRIPTION
## Summary
- prevent the inspiration panel from auto-expanding every folder on initial load while still priming the cached folder set
- tighten the folder discovery effect to only expand newly discovered paths when the user already has expanded folders and to keep the known folder cache in sync

## Testing
- `eslint . --ext .ts,.tsx --report-unused-disable-directives --max-warnings=0`


------
https://chatgpt.com/codex/tasks/task_e_68e4d9afa5f483319baa6e7e8a6c0892