### PR TITLE
Split data backup settings into local and GitHub sections

### DIFF
--- a/src/routes/__tests__/BackupHistorySection.test.tsx
+++ b/src/routes/__tests__/BackupHistorySection.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { ToastProvider } from '../../components/ToastProvider'
-import { DataBackupSection } from '../Settings'
+import { BackupHistorySection } from '../Settings'
 import { useAuthStore } from '../../stores/auth'
 import { db } from '../../stores/database'
 import { encryptString } from '../../lib/crypto'
@@ -84,14 +84,14 @@ async function createHistoryEntries() {
   return backupHistory.listBackupHistory(email)
 }
 
-describe('DataBackupSection history panel', () => {
+describe('BackupHistorySection history panel', () => {
   it('renders backup history entries with preview and diff controls', async () => {
     const entries = await createHistoryEntries()
     expect(entries.length).toBeGreaterThanOrEqual(2)
 
     render(
       <ToastProvider>
-        <DataBackupSection />
+        <BackupHistorySection />
       </ToastProvider>,
     )
 


### PR DESCRIPTION
## Summary
- refactor settings to provide a shared backup state via context and expose dedicated LocalBackupSection and GithubBackupSection components
- update the data management navigation to link to the new local and GitHub backup views
- adjust the backup history test suite to import the renamed components

## Testing
- pnpm vitest run src/routes/__tests__/BackupHistorySection.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68e4f2b19ab48331b56dad6e72154048