### PR TITLE
Stop auto-expanding inspiration folders on note selection

### DIFF
--- a/src/routes/Docs/InspirationPanel.tsx
+++ b/src/routes/Docs/InspirationPanel.tsx
@@ -1280,14 +1280,13 @@ export function InspirationPanel({ className }: InspirationPanelProps) {
     })
   }, [collectAllFolderPaths])
 
+  const [pendingFolderHighlight, setPendingFolderHighlight] = useState<string | null>(null)
+
   useEffect(() => {
-    if (!selectedId) return
-    const segments = selectedId.split('/').filter(Boolean)
-    if (segments.length <= 1) return
-    segments.pop()
-    const targetPath = segments.join('/')
-    expandFolderPath(targetPath)
-  }, [expandFolderPath, selectedId])
+    if (!pendingFolderHighlight) return
+    expandFolderPath(pendingFolderHighlight)
+    setPendingFolderHighlight(null)
+  }, [expandFolderPath, pendingFolderHighlight])
 
   useEffect(() => {
     const handler = window.setTimeout(() => {
@@ -1601,7 +1600,7 @@ export function InspirationPanel({ className }: InspirationPanelProps) {
         .slice(0, -1)
         .join('/')
       if (parentPath) {
-        expandFolderPath(parentPath)
+        setPendingFolderHighlight(parentPath)
         setActiveFolderPath(parentPath)
       }
 
@@ -1645,7 +1644,7 @@ export function InspirationPanel({ className }: InspirationPanelProps) {
     activeFolderPath,
     createNoteFile,
     createNoteInput,
-    expandFolderPath,
+    setPendingFolderHighlight,
     cleanupPendingAttachments,
     isDesktop,
     loadNote,
@@ -1670,7 +1669,7 @@ export function InspirationPanel({ className }: InspirationPanelProps) {
         set.add(sanitized)
         return Array.from(set)
       })
-      expandFolderPath(sanitized)
+      setPendingFolderHighlight(sanitized)
       setActiveFolderPath(sanitized)
       await refreshNotes()
       showToast({
@@ -1693,7 +1692,7 @@ export function InspirationPanel({ className }: InspirationPanelProps) {
   }, [
     createNoteFolder,
     createFolderInput,
-    expandFolderPath,
+    setPendingFolderHighlight,
     queueInspirationBackupSync,
     refreshNotes,
     showToast,
@@ -1719,7 +1718,7 @@ export function InspirationPanel({ className }: InspirationPanelProps) {
     try {
       const sanitized = await renameNoteFolder(renameFolderTargetPath, nextPath)
       await refreshNotes()
-      expandFolderPath(sanitized)
+      setPendingFolderHighlight(sanitized)
       setActiveFolderPath(prev => {
         if (!prev) return prev
         if (prev === renameFolderTargetPath) return sanitized
@@ -1747,7 +1746,7 @@ export function InspirationPanel({ className }: InspirationPanelProps) {
       setRenameFolderSubmitting(false)
     }
   }, [
-    expandFolderPath,
+    setPendingFolderHighlight,
     isDesktop,
     queueInspirationBackupSync,
     refreshNotes,

--- a/tests/inspiration-panel.test.tsx
+++ b/tests/inspiration-panel.test.tsx
@@ -311,6 +311,143 @@ describe('InspirationPanel folder listing', () => {
     expect(folderRow).toHaveClass('border-primary')
     expect(await screen.findByRole('button', { name: /Project Plan/ })).toBeInTheDocument()
   })
+
+  it('keeps folders collapsed when switching notes', async () => {
+    const now = Date.now()
+    const folderNote = {
+      id: 'Projects/Project Plan',
+      title: 'Project Plan',
+      createdAt: now,
+      updatedAt: now,
+      excerpt: '',
+      searchText: '',
+      tags: [],
+      attachments: [],
+    }
+    const rootNote = {
+      id: 'Inbox Note',
+      title: 'Inbox Note',
+      createdAt: now,
+      updatedAt: now,
+      excerpt: '',
+      searchText: '',
+      tags: [],
+      attachments: [],
+    }
+    listNotesMock.mockResolvedValue([folderNote, rootNote])
+    listNoteFoldersMock.mockResolvedValue(['Projects'])
+    const user = userEvent.setup()
+
+    renderPanel()
+
+    const collapseToggle = await screen.findByRole('button', { name: '折叠 Projects' })
+    await user.click(collapseToggle)
+
+    const expandToggle = await screen.findByRole('button', { name: '展开 Projects' })
+    await waitFor(() => {
+      expect(expandToggle).toHaveAttribute('aria-expanded', 'false')
+    })
+
+    await user.click(await screen.findByRole('button', { name: 'Inbox Note' }))
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: '展开 Projects' })).toHaveAttribute(
+        'aria-expanded',
+        'false',
+      )
+    })
+  })
+
+  it('keeps folders collapsed after refreshing the list', async () => {
+    const now = Date.now()
+    const note = {
+      id: 'Projects/Project Plan',
+      title: 'Project Plan',
+      createdAt: now,
+      updatedAt: now,
+      excerpt: '',
+      searchText: '',
+      tags: [],
+      attachments: [],
+    }
+    listNotesMock.mockResolvedValue([note])
+    listNoteFoldersMock.mockResolvedValue(['Projects'])
+    const user = userEvent.setup()
+
+    renderPanel()
+
+    const collapseToggle = await screen.findByRole('button', { name: '折叠 Projects' })
+    await user.click(collapseToggle)
+
+    const expandToggle = await screen.findByRole('button', { name: '展开 Projects' })
+    await waitFor(() => {
+      expect(expandToggle).toHaveAttribute('aria-expanded', 'false')
+    })
+
+    await user.click(screen.getByRole('button', { name: '刷新列表' }))
+
+    await waitFor(() => {
+      expect(listNotesMock).toHaveBeenCalledTimes(2)
+    })
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: '展开 Projects' })).toHaveAttribute(
+        'aria-expanded',
+        'false',
+      )
+    })
+  })
+
+  it('keeps folders collapsed after toggling search mode', async () => {
+    const now = Date.now()
+    const note = {
+      id: 'Projects/Project Plan',
+      title: 'Project Plan',
+      createdAt: now,
+      updatedAt: now,
+      excerpt: '',
+      searchText: '',
+      tags: [],
+      attachments: [],
+    }
+    listNotesMock.mockResolvedValue([note])
+    listNoteFoldersMock.mockResolvedValue(['Projects'])
+    const user = userEvent.setup()
+
+    renderPanel()
+
+    const collapseToggle = await screen.findByRole('button', { name: '折叠 Projects' })
+    await user.click(collapseToggle)
+
+    const expandToggle = await screen.findByRole('button', { name: '展开 Projects' })
+    await waitFor(() => {
+      expect(expandToggle).toHaveAttribute('aria-expanded', 'false')
+    })
+
+    const searchInput = screen.getByRole('searchbox', { name: '搜索笔记' })
+    await user.type(searchInput, 'Project')
+
+    await waitFor(() => {
+      expect(screen.getByText(/搜索结果/)).toBeInTheDocument()
+    })
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: '展开 Projects' })).toHaveAttribute(
+        'aria-expanded',
+        'false',
+      )
+    })
+
+    const clearButton = await screen.findByRole('button', { name: '清除搜索' })
+    await user.click(clearButton)
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: '展开 Projects' })).toHaveAttribute(
+        'aria-expanded',
+        'false',
+      )
+    })
+  })
 })
 
 describe('InspirationPanel handleCreateFolder', () => {


### PR DESCRIPTION
## Summary
- remove the selected-note side effect that expanded folders automatically and gate programmatic expansion behind an explicit pending highlight state
- keep folder expansion changes tied to user actions while still surfacing newly created or renamed folders
- extend inspiration panel tests to assert collapsed folders stay collapsed across note switches, refreshes, and search mode changes

## Testing
- pnpm vitest tests/inspiration-panel.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68e52cd4827083319a762c4edea17512