### PR TITLE
Ensure inspiration note GitHub sync handles commit messages and rollbacks

### DIFF
--- a/src/lib/inspiration-github.ts
+++ b/src/lib/inspiration-github.ts
@@ -102,9 +102,14 @@ async function resolveGithubSyncContext(): Promise<GithubSyncContext | null> {
   return { token, owner, repo, branch }
 }
 
+export interface SyncGithubNoteFileOptions {
+  commitMessage?: string
+}
+
 export async function syncGithubNoteFile(
   relativePath: string,
   content: string,
+  options?: SyncGithubNoteFileOptions,
 ): Promise<boolean> {
   const context = await resolveGithubSyncContext()
   if (!context) {
@@ -117,7 +122,9 @@ export async function syncGithubNoteFile(
   }
 
   const remotePath = buildFileRemotePath(normalizedRelative)
-  const commitMessage = `Create inspiration note: ${normalizedRelative}`
+  const commitMessage = options?.commitMessage?.trim()
+    ? options.commitMessage
+    : `Create inspiration note: ${normalizedRelative}`
 
   try {
     await uploadGithubBackup(


### PR DESCRIPTION
## Summary
- allow `syncGithubNoteFile` callers to override the commit message used during uploads
- update `saveNote` to preserve previous content, provide descriptive commit messages, and roll back on sync failure
- expand inspiration notes tests to cover GitHub sync commits and failure recovery paths

## Testing
- pnpm vitest --run tests/inspiration-notes.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68e5689759808331a16fde78219cfe15