### PR TITLE
feat: customize inspiration backup failure messaging

### DIFF
--- a/src/routes/Docs/InspirationPanel.tsx
+++ b/src/routes/Docs/InspirationPanel.tsx
@@ -52,7 +52,10 @@ import {
   type NoteDetail,
   type NoteSummary,
 } from '../../lib/inspiration-notes'
-import { queueInspirationBackupSync } from '../../lib/inspiration-sync'
+import {
+  queueInspirationBackupSync,
+  type InspirationBackupSyncOptions,
+} from '../../lib/inspiration-sync'
 import { normalizeUrl, openExternal } from '../../lib/external'
 import {
   importFileToVault,
@@ -132,6 +135,13 @@ function toNoteSummary(detail: NoteDetail): NoteSummary {
     tags: detail.tags,
     attachments: detail.attachments,
   }
+}
+
+const AUTO_BACKUP_FAILURE_TOAST_OPTIONS: InspirationBackupSyncOptions = {
+  errorToast: {
+    title: '自动备份未完成',
+    description: 'GitHub 自动备份暂时失败，但笔记内容已成功保存；稍后会继续尝试。',
+  },
 }
 
 type InspirationPanelProps = {
@@ -1609,7 +1619,7 @@ export function InspirationPanel({ className }: InspirationPanelProps) {
         if (showSuccessToast) {
           showToast({ title: '保存成功', description: '笔记内容已更新。', variant: 'success' })
         }
-        queueInspirationBackupSync(showToast)
+        queueInspirationBackupSync(showToast, AUTO_BACKUP_FAILURE_TOAST_OPTIONS)
         return saved
       } catch (err) {
         console.error('Failed to save inspiration note', err)
@@ -1779,7 +1789,7 @@ export function InspirationPanel({ className }: InspirationPanelProps) {
         description: `已新建 Markdown 文件：${note.id}`,
         variant: 'success',
       })
-      queueInspirationBackupSync(showToast)
+      queueInspirationBackupSync(showToast, { errorToast: false })
 
       setCreateNoteDialogOpen(false)
       setCreateNoteInput('')

--- a/tests/inspiration-panel.test.tsx
+++ b/tests/inspiration-panel.test.tsx
@@ -59,6 +59,12 @@ const removeVaultFileMock = vi.fn<(relPath: string) => Promise<void>>()
 
 const clipboardWriteTextMock = vi.fn<(text: string) => Promise<void>>()
 const queueInspirationBackupSyncMock = vi.fn()
+const AUTO_BACKUP_FAILURE_TOAST_OPTIONS = {
+  errorToast: {
+    title: '自动备份未完成',
+    description: 'GitHub 自动备份暂时失败，但笔记内容已成功保存；稍后会继续尝试。',
+  },
+} as const
 
 vi.mock('../src/lib/inspiration-notes', () => ({
   NOTE_FEATURE_DISABLED_MESSAGE: '仅在桌面端可用',
@@ -719,6 +725,11 @@ describe('InspirationPanel handleCreateFile', () => {
     await waitFor(() => {
       expect(queueInspirationBackupSyncMock).toHaveBeenCalledTimes(1)
     })
+    const lastCall =
+      queueInspirationBackupSyncMock.mock.calls[
+        queueInspirationBackupSyncMock.mock.calls.length - 1
+      ]
+    expect(lastCall?.[1]).toEqual({ errorToast: false })
   })
 
   it('prefills the create file dialog with the active folder and appends it when missing', async () => {
@@ -1038,6 +1049,11 @@ describe('InspirationPanel synchronization queue', () => {
     await waitFor(() => {
       expect(queueInspirationBackupSyncMock).toHaveBeenCalledTimes(1)
     })
+    const lastCall =
+      queueInspirationBackupSyncMock.mock.calls[
+        queueInspirationBackupSyncMock.mock.calls.length - 1
+      ]
+    expect(lastCall?.[1]).toEqual(AUTO_BACKUP_FAILURE_TOAST_OPTIONS)
   })
 
   it('does not queue sync when saving fails', async () => {


### PR DESCRIPTION
## Summary
- allow callers of the inspiration backup scheduler to disable or override GitHub failure toasts while clarifying the default copy
- update manual note creation/save flows to opt into the new messaging so backup issues aren’t mistaken for sync failures
- extend the inspiration panel test suite to assert the suppression and replacement behaviours of the backup toast options

## Testing
- pnpm vitest run tests/inspiration-panel.test.tsx -t "creates a markdown file, refreshes notes, loads it, and shows a success toast"
- pnpm vitest run tests/inspiration-panel.test.tsx -t "queues GitHub sync after a successful save"

------
https://chatgpt.com/codex/tasks/task_e_68e56f97ccfc8331915e1d221e1fe555