### PR TITLE
Run typecheck before Vite build

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "cross-env CHOKIDAR_USEPOLLING=1 VITE_FORCE_POLLING=1 vite",
-    "build": "tsc -b && vite build --base=./",
+    "build": "pnpm run typecheck && vite build --base=./",
     "preview": "vite preview --strictPort --port 5173",
     "test": "vitest --run",
     "test:watch": "vitest",

--- a/src/lib/inspiration-github.ts
+++ b/src/lib/inspiration-github.ts
@@ -214,8 +214,8 @@ export async function syncGithubNoteFile(
     : `Create inspiration note: ${normalizedRelative}`
 
   try {
-    await runGithubUploadWithConflictRetry(context, () =>
-      uploadGithubBackup(
+    await runGithubUploadWithConflictRetry(context, async () => {
+      await uploadGithubBackup(
         {
           token: context.token,
           owner: context.owner,
@@ -225,8 +225,8 @@ export async function syncGithubNoteFile(
           content,
         },
         { commitMessage, maxRetries: 1 },
-      ),
-    )
+      )
+    })
     return true
   } catch (error) {
     const message = readErrorMessage(error) || '上传 GitHub 文件失败，请稍后再试。'
@@ -246,8 +246,8 @@ export async function ensureGithubNoteFolder(relativePath: string): Promise<bool
   const commitMessage = `Ensure inspiration folder: ${targetLabel}`
 
   try {
-    await runGithubUploadWithConflictRetry(context, () =>
-      uploadGithubBackup(
+    await runGithubUploadWithConflictRetry(context, async () => {
+      await uploadGithubBackup(
         {
           token: context.token,
           owner: context.owner,
@@ -257,8 +257,8 @@ export async function ensureGithubNoteFolder(relativePath: string): Promise<bool
           content: '',
         },
         { commitMessage, maxRetries: 1 },
-      ),
-    )
+      )
+    })
     return true
   } catch (error) {
     const message = readErrorMessage(error) || '上传 GitHub 文件失败，请稍后再试。'


### PR DESCRIPTION
## Summary
- update the build script to run the existing typecheck step before Vite compiles
- adjust the GitHub upload conflict retry callback to be async and await the upload so typechecking passes

## Testing
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68e592a8e750833183d5dfa4aa89ed73